### PR TITLE
deploy/rbac: Allow provisioner to get csi credential secrets

### DIFF
--- a/deploy/base/controller-rbac.yaml
+++ b/deploy/base/controller-rbac.yaml
@@ -9,6 +9,9 @@ metadata:
   name: csi-gcs-provisioner
 rules:
   - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: [""]

--- a/docs/contributing/authors.md
+++ b/docs/contributing/authors.md
@@ -11,3 +11,4 @@
 
 - Ofek Lev [:octicons-octoface:](https://github.com/ofek) [:material-twitter:](https://twitter.com/Ofekmeister)
 - Jonatan Männchen [:octicons-octoface:](https://github.com/maennchen)
+- Joel Cressy [:octicons-octoface:](https://github.com/jtcressy) [:material-twitter:](https://twitter.com/jtcressy)


### PR DESCRIPTION
This was set for the node mounter, but not the provisioner, preventing persistent volume claims from being provisioned.