### PR TITLE
Support Volume Expansion

### DIFF
--- a/deploy/base/controller-rbac.yaml
+++ b/deploy/base/controller-rbac.yaml
@@ -10,7 +10,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "delete"]
@@ -46,4 +46,40 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: csi-gcs-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-gcs-resizer
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-gcs-resizer
+subjects:
+  - kind: ServiceAccount
+    name: csi-gcs-controller
+roleRef:
+  kind: ClusterRole
+  name: csi-gcs-resizer
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/base/controller-statefulset.yaml
+++ b/deploy/base/controller-statefulset.yaml
@@ -42,6 +42,18 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-resizer
+          image: quay.io/k8scsi/csi-resizer:v0.2.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-gcs-controller
           image: docker.io/ofekmeister/csi-gcs:latest
           imagePullPolicy: Always

--- a/docs/csi_compatibility.md
+++ b/docs/csi_compatibility.md
@@ -1,0 +1,18 @@
+# CSI Specification Compatibility
+
+This page describes compatibility to the [CSI specification](https://github.com/container-storage-interface/spec/blob/master/spec.md).
+
+## Capacity
+
+:warning:
+**Google Cloud Storage does not allow to enforce capacity limits. Therefore, this driver is unable to provide capacity limit enforcement.**
+
+The driver only sets a `capacity` label for the `bucket` containing the requested bytes.
+
+## Snapshots
+
+[Snapshots](https://github.com/container-storage-interface/spec/blob/master/spec.md#createsnapshot) are not currently supported, but are on the roadmap for the future.
+
+## `CreateVolume` / `VolumeContentSource`
+
+[`CreateVolume` / `VolumeContentSource`](https://github.com/container-storage-interface/spec/blob/master/spec.md#createvolume) is not currently supported, but is on the roadmap for the future.

--- a/docs/csi_compatibility.md
+++ b/docs/csi_compatibility.md
@@ -4,8 +4,8 @@ This page describes compatibility to the [CSI specification](https://github.com/
 
 ## Capacity
 
-:warning:
-**Google Cloud Storage does not allow to enforce capacity limits. Therefore, this driver is unable to provide capacity limit enforcement.**
+!!! warning "Important"
+    Google Cloud Storage has no concept of capacity limits. Therefore, this driver is unable to provide capacity limit enforcement.
 
 The driver only sets a `capacity` label for the `bucket` containing the requested bytes.
 

--- a/docs/dynamic_provisioning.md
+++ b/docs/dynamic_provisioning.md
@@ -103,6 +103,8 @@ parameters:
 | `csi.storage.k8s.io/node-publish-secret-namespace` | The namespace of the secret allowed to mount created buckets |
 | `csi.storage.k8s.io/provisioner-secret-name` | The name of the secret allowed to create buckets |
 | `csi.storage.k8s.io/provisioner-secret-namespace` | The namespace of the secret allowed to create buckets |
+| `csi.storage.k8s.io/controller-expand-secret-name` | The name of the secret allowed to expand [bucket capacity](csi_compatibility.md#capacity) |
+| `csi.storage.k8s.io/controller-expand-secret-namespace` | The namespace of the secret allowed to expand [bucket capacity](csi_compatibility.md#capacity) |
 | `gcs.csi.ofek.dev/project-id` | The project to create the buckets in. If not specified, `projectId` will be looked up in the provisioner's secret |
 | `gcs.csi.ofek.dev/location` | The [location][gcs-location] to create buckets at (default `US` multi-region) |
 

--- a/examples/dynamic/sc.yaml
+++ b/examples/dynamic/sc.yaml
@@ -4,10 +4,12 @@ metadata:
   name: csi-gcs
 provisioner: gcs.csi.ofek.dev
 volumeBindingMode: Immediate
-allowVolumeExpansion: false
+allowVolumeExpansion: true
 reclaimPolicy: Delete
 parameters:
   csi.storage.k8s.io/node-publish-secret-name: csi-gcs-secret-mounter
   csi.storage.k8s.io/node-publish-secret-namespace: default
   csi.storage.k8s.io/provisioner-secret-name: csi-gcs-secret-creator
   csi.storage.k8s.io/provisioner-secret-namespace: default
+  csi.storage.k8s.io/controller-expand-secret-name: csi-gcs-secret-creator
+  csi.storage.k8s.io/controller-expand-secret-namespace: default

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
   - Getting started: getting_started.md
   - Static provisioning: static_provisioning.md
   - Dynamic provisioning: dynamic_provisioning.md
+  - CSI Compatibility: csi_compatibility.md
   - Contributing:
     - Setup: contributing/setup.md
     - Authors: contributing/authors.md

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -84,7 +84,7 @@ func CreateDir(d string) error {
 	return nil
 }
 
-func GetKey(secrets map[string]string, options map[string]string, keyStoragePath string) (string, error) {
+func GetKey(secrets map[string]string, keyStoragePath string) (string, error) {
 	if _, err := os.Stat(keyStoragePath); os.IsNotExist(err) {
 		os.Mkdir(keyStoragePath, 0700)
 	}


### PR DESCRIPTION
Closes #11 

This change does not actually implement capacity limits for GCS since it doesn't seem to be supported. Instead this only allows to set a new capacity in the PVC to update the `capacity` label of the bucket.

Since having this capability exposed could mean that people assume support for it, I added a page describing the issue to the docs.