### PR TITLE
Switch to specific gcsfuse tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR ${GOPATH}
 RUN mkdir /tmp/bin
 
 # Install gcsfuse using the specified version or commit hash
-RUN go get -u github.com/googlecloudplatform/gcsfuse
+RUN go get -u github.com/googlecloudplatform/gcsfuse && cd ${GOPATH}/src/github.com/googlecloudplatform/gcsfuse && git checkout "v${gcsfuse_version}"
 RUN go install github.com/googlecloudplatform/gcsfuse/tools/build_gcsfuse
 RUN mkdir /tmp/gcsfuse
 RUN build_gcsfuse ${GOPATH}/src/github.com/googlecloudplatform/gcsfuse /tmp/gcsfuse ${gcsfuse_version} -ldflags "all=${global_ldflags}" -ldflags "-X main.gcsfuseVersion=${gcsfuse_version} ${global_ldflags}"

--- a/tasks/constants.py
+++ b/tasks/constants.py
@@ -1,4 +1,4 @@
-GCSFUSE_VERSION = '0.27.0'
+GCSFUSE_VERSION = '0.28.1'
 
 REPO = 'ofekmeister'
 IMAGE = 'csi-gcs'

--- a/tasks/constants.py
+++ b/tasks/constants.py
@@ -1,4 +1,4 @@
-GCSFUSE_VERSION = '0.28.1'
+GCSFUSE_VERSION = '0.33.2'
 
 REPO = 'ofekmeister'
 IMAGE = 'csi-gcs'


### PR DESCRIPTION
I'm using the latest version of the GCS CSI driver (v0.6.1) and I see the memory issue related to gcsfuse.

> High memory usage when copying files to a bucket 
> https://github.com/GoogleCloudPlatform/gcsfuse/issues/467

Add logic to use a specific `gcsfuse` version instead of building it from the `master` branch
Update default  `gcsfuse` version to `0.28.1` because the previous version hasn't build arg ([v0.27.0#build_gcsfuse](https://github.com/GoogleCloudPlatform/gcsfuse/blob/v0.27.0/tools/build_gcsfuse/main.go#L143) vs [v0.28.1#build_gcsfuse](https://github.com/GoogleCloudPlatform/gcsfuse/blob/v0.28.1/tools/build_gcsfuse/main.go#L143))

I tested two scenarios:
1. Copy files into container mounted dir from local machine (`kubectl cp ...`)
2. Copy files in mounted dir between subdirs

0.33.1 has issues with memory
![image](https://user-images.githubusercontent.com/892060/108649829-113fba80-74f9-11eb-977f-2c3c96ab02ff.png)


0.28.1 works good
![image](https://user-images.githubusercontent.com/892060/108649741-e6556680-74f8-11eb-92b8-9e4bddbfc604.png)

