### PR TITLE
Support default credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ __pycache__
 # Artifacts
 /bin/*
 !/bin/.gitkeep
+
+# python env
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__
 
 # Python environments
 /.tox
+.venv/
 
 # Test Service Account
 /service-account.json
@@ -30,5 +31,5 @@ __pycache__
 /bin/*
 !/bin/.gitkeep
 
-# python env
-.venv/
+# go vendor
+vendor/

--- a/docs/.snippets/links.txt
+++ b/docs/.snippets/links.txt
@@ -14,3 +14,4 @@
 [gcsfuse-implicit-dirs]: https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/semantics.md#implicit-directories
 [fuse-mount-options]: http://man7.org/linux/man-pages/man8/mount.fuse.8.html#OPTIONS
 [libfuse-github]: https://github.com/libfuse/libfuse
+[key-locator-heuristics]: https://pkg.go.dev/golang.org/x/oauth2/google#FindDefaultCredentials

--- a/docs/dynamic_provisioning.md
+++ b/docs/dynamic_provisioning.md
@@ -112,8 +112,8 @@ parameters: ...
 | `gcs.csi.ofek.dev/kms-key-id`                           | (optional) KMS encryption key ID. (projects/my-pet-project/locations/us-east1/keyRings/my-key-ring/cryptoKeys/my-key)                                                                                                                     |
 | `gcs.csi.ofek.dev/max-retry-sleep`                      | The maximum duration allowed to sleep in a retry loop with exponential backoff for failed requests to GCS backend. Once the backoff duration exceeds this limit, the retry stops. The default is 1 minute. A value of 0 disables retries. |
 
-> You also can just delete the secret definition, the code will automatically fine the service account key follow some order.
-> Refer: https://pkg.go.dev/golang.org/x/oauth2/google#FindDefaultCredentials
+!!! tip
+    You may omit the secret definition and let the code automatically detect the service account key using [standard heuristics][key-locator-heuristics].
 
 ### Persistent Volume Claim Parameters
 

--- a/docs/dynamic_provisioning.md
+++ b/docs/dynamic_provisioning.md
@@ -112,6 +112,9 @@ parameters: ...
 | `gcs.csi.ofek.dev/kms-key-id`                           | (optional) KMS encryption key ID. (projects/my-pet-project/locations/us-east1/keyRings/my-key-ring/cryptoKeys/my-key)                                                                                                                     |
 | `gcs.csi.ofek.dev/max-retry-sleep`                      | The maximum duration allowed to sleep in a retry loop with exponential backoff for failed requests to GCS backend. Once the backoff duration exceeds this limit, the retry stops. The default is 1 minute. A value of 0 disables retries. |
 
+> You also can just delete the secret definition, the code will automatically fine the service account key follow some order.
+> Refer: https://pkg.go.dev/golang.org/x/oauth2/google#FindDefaultCredentials
+
 ### Persistent Volume Claim Parameters
 
 ```yaml

--- a/docs/static_provisioning.md
+++ b/docs/static_provisioning.md
@@ -84,8 +84,8 @@ See the CSI section of the [Kubernetes Volume docs][k8s-volume-csi].
 The contents of the JSON key may be passed in as a secret defined in
 `PersistentVolume.spec.csi.nodePublishSecretRef`. The name of the key in the secret is `key`.
 
-> You also can just delete the secret definition, the code will automatically fine the service account key follow some order.
-> Refer: https://pkg.go.dev/golang.org/x/oauth2/google#FindDefaultCredentials
+!!! tip
+    You may omit the secret definition and let the code automatically detect the service account key using [standard heuristics][key-locator-heuristics].
 
 ### Bucket
 

--- a/docs/static_provisioning.md
+++ b/docs/static_provisioning.md
@@ -84,6 +84,9 @@ See the CSI section of the [Kubernetes Volume docs][k8s-volume-csi].
 The contents of the JSON key may be passed in as a secret defined in
 `PersistentVolume.spec.csi.nodePublishSecretRef`. The name of the key in the secret is `key`.
 
+> You also can just delete the secret definition, the code will automatically fine the service account key follow some order.
+> Refer: https://pkg.go.dev/golang.org/x/oauth2/google#FindDefaultCredentials
+
 ### Bucket
 
 The bucket name is resolved in the following order:

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/kubernetes-csi/csi-test/v3 v3.1.1-0.20200525083111-e89bc15a6e5e
 	github.com/onsi/ginkgo v1.10.3
 	github.com/onsi/gomega v1.7.1
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/api v0.4.0
 	google.golang.org/grpc v1.26.0
 	k8s.io/apimachinery v0.17.1-beta.0

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"github.com/ofek/csi-gcs/pkg/flags"
 	"github.com/ofek/csi-gcs/pkg/util"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -68,15 +69,26 @@ func (d *GCSDriver) CreateVolume(ctx context.Context, req *csi.CreateVolumeReque
 		options = flags.MergeAnnotations(options, req.Parameters)
 	}
 
-	// Retrieve Key Secret
-	keyFile, err := util.GetKey(req.Secrets, KeyStoragePath)
-	if err != nil {
-		return nil, err
+	var clientOpt option.ClientOption
+	if len(req.Secrets) == 0 {
+		// Find default credentials
+		creds, err := google.FindDefaultCredentials(ctx, storage.ScopeReadOnly)
+		if err != nil {
+			return nil, err
+		}
+		clientOpt = option.WithCredentials(creds)
+	} else {
+		// Retrieve Secret Key
+		keyFile, err := util.GetKey(req.Secrets, KeyStoragePath)
+		if err != nil {
+			return nil, err
+		}
+		clientOpt = option.WithCredentialsFile(keyFile)
+		defer util.CleanupKey(keyFile, KeyStoragePath)
 	}
-	defer util.CleanupKey(keyFile, KeyStoragePath)
 
 	// Creates a client.
-	client, err := storage.NewClient(ctx, option.WithCredentialsFile(keyFile))
+	client, err := storage.NewClient(ctx, clientOpt)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to create client: %v", err)
 	}
@@ -139,14 +151,26 @@ func (d *GCSDriver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeReque
 		return nil, status.Error(codes.InvalidArgument, "missing volume id")
 	}
 
-	keyFile, err := util.GetKey(req.Secrets, KeyStoragePath)
-	if err != nil {
-		return nil, err
+	var clientOpt option.ClientOption
+	if len(req.Secrets) == 0 {
+		// Find default credentials
+		creds, err := google.FindDefaultCredentials(ctx, storage.ScopeReadOnly)
+		if err != nil {
+			return nil, err
+		}
+		clientOpt = option.WithCredentials(creds)
+	} else {
+		// Retrieve Secret Key
+		keyFile, err := util.GetKey(req.Secrets, KeyStoragePath)
+		if err != nil {
+			return nil, err
+		}
+		clientOpt = option.WithCredentialsFile(keyFile)
+		defer util.CleanupKey(keyFile, KeyStoragePath)
 	}
-	defer util.CleanupKey(keyFile, KeyStoragePath)
 
 	// Creates a client.
-	client, err := storage.NewClient(ctx, option.WithCredentialsFile(keyFile))
+	client, err := storage.NewClient(ctx, clientOpt)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to create client: %v", err)
 	}
@@ -201,14 +225,26 @@ func (d *GCSDriver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Val
 
 	bucketName := req.VolumeId
 
-	keyFile, err := util.GetKey(req.Secrets, KeyStoragePath)
-	if err != nil {
-		return nil, err
+	var clientOpt option.ClientOption
+	if len(req.Secrets) == 0 {
+		// Find default credentials
+		creds, err := google.FindDefaultCredentials(ctx, storage.ScopeReadOnly)
+		if err != nil {
+			return nil, err
+		}
+		clientOpt = option.WithCredentials(creds)
+	} else {
+		// Retrieve Secret Key
+		keyFile, err := util.GetKey(req.Secrets, KeyStoragePath)
+		if err != nil {
+			return nil, err
+		}
+		clientOpt = option.WithCredentialsFile(keyFile)
+		defer util.CleanupKey(keyFile, KeyStoragePath)
 	}
-	defer util.CleanupKey(keyFile, KeyStoragePath)
 
 	// Creates a client.
-	client, err := storage.NewClient(ctx, option.WithCredentialsFile(keyFile))
+	client, err := storage.NewClient(ctx, clientOpt)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to create client: %v", err)
 	}
@@ -288,15 +324,26 @@ func (d *GCSDriver) ControllerExpandVolume(ctx context.Context, req *csi.Control
 		return nil, status.Error(codes.InvalidArgument, "missing volume id")
 	}
 
-	// Retrieve Key Secret
-	keyFile, err := util.GetKey(req.Secrets, KeyStoragePath)
-	if err != nil {
-		return nil, err
+	var clientOpt option.ClientOption
+	if len(req.Secrets) == 0 {
+		// Find default credentials
+		creds, err := google.FindDefaultCredentials(ctx, storage.ScopeReadOnly)
+		if err != nil {
+			return nil, err
+		}
+		clientOpt = option.WithCredentials(creds)
+	} else {
+		// Retrieve Secret Key
+		keyFile, err := util.GetKey(req.Secrets, KeyStoragePath)
+		if err != nil {
+			return nil, err
+		}
+		clientOpt = option.WithCredentialsFile(keyFile)
+		defer util.CleanupKey(keyFile, KeyStoragePath)
 	}
-	defer util.CleanupKey(keyFile, KeyStoragePath)
 
 	// Creates a client.
-	client, err := storage.NewClient(ctx, option.WithCredentialsFile(keyFile))
+	client, err := storage.NewClient(ctx, clientOpt)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to create client: %v", err)
 	}


### PR DESCRIPTION
This PR be able to use default credentials when the secret not set, the method will find the certificates based on a specific order -
https://pkg.go.dev/golang.org/x/oauth2/google#FindDefaultCredentials

In my use case, for security reasons, our company does not allow any keys to be stored on the cluster, and in this case we would like to use the default service account to access bucket.

Also I think this PR related to #60 
