### PR TITLE
Advertise the readiness of the driver on each node.

### DIFF
--- a/deploy/base/rbac.yaml
+++ b/deploy/base/rbac.yaml
@@ -16,7 +16,7 @@ rules:
   verbs: ["delete"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "list", "update"]
+  verbs: ["get", "list", "update", "patch"]
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "list"]

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,46 @@
 # Troubleshooting
+## Warnings events from pods scheduled on newly started nodes when mounting csi-gcs volumes
 
------
+Warnings, like the one below, can be seen from pods scheduled on newly started nodes.
 
-## TODO
+```
+MountVolume.MountDevice failed for volume "xxxx" : kubernetes.io/csi: attacher.MountDevice failed to create newCsiDriverClient: driver name gcs.csi.ofek.dev not found in the list of registered CSI drivers
+```
+
+Those warnings are temporary and reflect the csi-gcs driver is still starting. Kubernetes will retry until the csi-gcs driver is ready.
+
+It's possible to avoid those warnings by adding a node selector or affinity using the node label `gcs.csi.ofek.dev/driver-ready=true`.
+
+> Adding such node selector or affinity will trade the time spend waiting for volume mounting retries against time waiting for scheduling.
+
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+    name: pod-mount-csi-gcs-volume
+spec:
+  // ...
+  nodeSelector:
+    gcs.csi.ofek.dev/driver-ready: "true"
+```
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+    name: pod-mount-csi-gcs-volume
+spec:
+  // ...
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: gcs.csi.ofek.dev/driver-ready
+            operator: In
+            values:
+            - "true"
+```
+
+You can also add an admission mutating webhook to automatically inject such node selector or affinity in all pods mounting csi-gcs volumes.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,6 +13,7 @@ It's possible to avoid those warnings by adding a node selector or affinity usin
 
 > Adding such node selector or affinity will trade the time spend waiting for volume mounting retries with time waiting for scheduling.
 
+> The exact label added is `<driver name>/driver-ready`, by default `<driver name>` is `gcs.csi.ofek.dev`
 
 ```
 apiVersion: v1

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,7 +11,7 @@ Those warnings are temporary and reflect the csi-gcs driver is still starting. K
 
 It's possible to avoid those warnings by adding a node selector or affinity using the node label `gcs.csi.ofek.dev/driver-ready=true`.
 
-> Adding such node selector or affinity will trade the time spend waiting for volume mounting retries against time waiting for scheduling.
+> Adding such node selector or affinity will trade the time spend waiting for volume mounting retries with time waiting for scheduling.
 
 
 ```

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -39,7 +39,7 @@ func NewGCSDriver(name, node, endpoint string, version string, deleteOrphanedPod
 
 func (d *GCSDriver) Run() error {
 	// set the driver-ready label to false at the beginning to handle edge-case where the controller didn't terminated gracefully
-	if err := util.SetDriverReadyLabel(d.nodeName, false); err != nil {
+	if err := util.SetDriverReadyLabel(d.name, d.nodeName, false); err != nil {
 		klog.Warningf("Unable to set driver-ready=false label on the node, error: %v", err)
 	}
 
@@ -80,7 +80,7 @@ func (d *GCSDriver) Run() error {
 	csi.RegisterIdentityServer(d.server, d)
 	csi.RegisterNodeServer(d.server, d)
 	csi.RegisterControllerServer(d.server, d)
-	if err = util.SetDriverReadyLabel(d.nodeName, true); err != nil {
+	if err = util.SetDriverReadyLabel(d.name, d.nodeName, true); err != nil {
 		klog.Warningf("unable to set driver-ready=true label on the node, error: %v", err)
 	}
 	return d.server.Serve(listener)
@@ -88,7 +88,7 @@ func (d *GCSDriver) Run() error {
 
 func (d *GCSDriver) stop() {
 	d.server.Stop()
-	if err := util.SetDriverReadyLabel(d.nodeName, false); err != nil {
+	if err := util.SetDriverReadyLabel(d.name, d.nodeName, false); err != nil {
 		klog.Warningf("Unable to set driver-ready=false label on the node, error: %v", err)
 	}
 	klog.V(1).Info("CSI driver stopped")

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -40,7 +40,7 @@ func NewGCSDriver(name, node, endpoint string, version string, deleteOrphanedPod
 func (d *GCSDriver) Run() error {
 	// set the driver-ready label to false at the beginning to handle edge-case where the controller didn't terminated gracefully
 	if err := util.SetDriverReadyLabel(d.nodeName, false); err != nil {
-		klog.V(4).Infof("Unable to set driver-ready=false label on the node, error: %v", err)
+		klog.Warningf("Unable to set driver-ready=false label on the node, error: %v", err)
 	}
 
 	if len(d.mountPoint) == 0 {
@@ -81,7 +81,7 @@ func (d *GCSDriver) Run() error {
 	csi.RegisterNodeServer(d.server, d)
 	csi.RegisterControllerServer(d.server, d)
 	if err = util.SetDriverReadyLabel(d.nodeName, true); err != nil {
-		klog.V(4).Infof("unable to set driver-ready=true label on the node, error: %v", err)
+		klog.Warningf("unable to set driver-ready=true label on the node, error: %v", err)
 	}
 	return d.server.Serve(listener)
 }
@@ -89,7 +89,7 @@ func (d *GCSDriver) Run() error {
 func (d *GCSDriver) stop() {
 	d.server.Stop()
 	if err := util.SetDriverReadyLabel(d.nodeName, false); err != nil {
-		klog.V(4).Infof("Unable to set driver-ready=false label on the node, error: %v", err)
+		klog.Warningf("Unable to set driver-ready=false label on the node, error: %v", err)
 	}
 	klog.V(1).Info("CSI driver stopped")
 }

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -203,7 +203,7 @@ func SetDriverReadyLabel(nodeName string, isReady bool) (err error) {
 		Path  string `json:"path"`
 		Value string `json:"value"`
 	}{{
-		Op:    "replace",
+		Op:    "add",
 		Path:  "/metadata/labels/gcs.csi.ofek.dev~1driver-ready",
 		Value: strconv.FormatBool(isReady),
 	}}


### PR DESCRIPTION
This PR set the label `gcs.csi.ofek.dev/driver-ready={true,false}` on each node running csi-gcs to reflect the state of readiness of the driver. 

This allows pods to avoid nodes where csi-gcs is still starting up. 