### PR TITLE
Adding a helm chart

### DIFF
--- a/deploy/helm/csi-gcs/.helmignore
+++ b/deploy/helm/csi-gcs/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/csi-gcs/Chart.yaml
+++ b/deploy/helm/csi-gcs/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: csi-gcs
+description: A Helm chart for deploying a CSI driver for Google Container Storage
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.8.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.8.0"

--- a/deploy/helm/csi-gcs/templates/_helpers.tpl
+++ b/deploy/helm/csi-gcs/templates/_helpers.tpl
@@ -40,3 +40,14 @@ Create the name of the service account to use
 {{- default "csi-gcs" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the priority class to use
+*/}}
+{{- define "csi-gcs.priorityClassName" -}}
+{{- if .Values.priorityClass.create }}
+{{- default (include "csi-gcs.fullname" .) .Values.priorityClass.name }}
+{{- else }}
+{{- default "csi-gcs-priority" .Values.priorityClass.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/csi-gcs/templates/_helpers.tpl
+++ b/deploy/helm/csi-gcs/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "csi-gcs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "csi-gcs.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "csi-gcs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "csi-gcs.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "csi-gcs.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "csi-gcs" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/csi-gcs/templates/daemonset.yaml
+++ b/deploy/helm/csi-gcs/templates/daemonset.yaml
@@ -1,0 +1,139 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "csi-gcs.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "csi-gcs.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "csi-gcs.fullname" . }}
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: "Exists"
+      hostNetwork: true
+      serviceAccount: {{ include "csi-gcs.serviceAccountName" . }}
+      containers:
+      - name: csi-node-driver-registrar
+        image: {{ .Values.images.registrar.repository }}:{{ .Values.images.registrar.tag }}
+        imagePullPolicy: Always
+        args:
+        - "--v=5"
+        - "--csi-address=$(ADDRESS)"
+        - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: DRIVER_REG_SOCK_PATH
+          value: /var/lib/kubelet/plugins/{{ .Values.driverName }}/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: registration-dir
+          mountPath: /registration
+        - name: socket-dir
+          mountPath: /csi
+        resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+      - name: csi-provisioner
+        image: {{ .Values.images.provisioner.repository }}:{{ .Values.images.provisioner.tag }}
+        args:
+          - "--csi-address=$(ADDRESS)"
+          - "--extra-create-metadata"
+          - "--enable-leader-election"
+          - "--leader-election-namespace=$(NAMESPACE)"
+        env:
+          - name: ADDRESS
+            value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          - name: NAMESPACE
+            value: {{ .Release.Namespace }}
+        imagePullPolicy: "IfNotPresent"
+        volumeMounts:
+          - name: socket-dir
+            mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-resizer
+        image: {{ .Values.images.resizer.repository }}:{{ .Values.images.resizer.tag }}
+        args:
+          - "--v=5"
+          - "--csi-address=$(ADDRESS)"
+          - "--leader-election"
+          - "--leader-election-namespace=$(NAMESPACE)"
+        env:
+          - name: ADDRESS
+            value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          - name: NAMESPACE
+            value: {{ .Release.Namespace }}
+        imagePullPolicy: "IfNotPresent"
+        volumeMounts:
+          - name: socket-dir
+            mountPath: /var/lib/csi/sockets/pluginproxy/
+        resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+      - name: {{ include "csi-gcs.fullname" . }}
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+          allowPrivilegeEscalation: true
+        image: {{ .Values.images.driver.repository }}:{{ .Values.images.driver.tag }}
+        imagePullPolicy: Always
+        args:
+        - "--node-name=$(KUBE_NODE_NAME)"
+        # https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
+        - "--v=5"
+        - "--delete-orphaned-pods=true"
+        env:
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: fuse-device
+          mountPath: /dev/fuse
+        - name: mountpoint-dir
+          mountPath: /var/lib/kubelet/pods
+          mountPropagation: Bidirectional
+        - name: socket-dir
+          mountPath: /csi
+        resources:
+          limits:
+            cpu: 1
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 80Mi
+      volumes:
+      - name: fuse-device
+        hostPath:
+          path: /dev/fuse
+      # https://kubernetes-csi.github.io/docs/deploying.html#driver-volume-mounts
+      - name: socket-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/{{ .Values.driverName }}
+          type: DirectoryOrCreate
+      - name: mountpoint-dir
+        hostPath:
+          path: /var/lib/kubelet/pods
+          type: Directory
+      - name: registration-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry
+          type: Directory

--- a/deploy/helm/csi-gcs/templates/daemonset.yaml
+++ b/deploy/helm/csi-gcs/templates/daemonset.yaml
@@ -11,9 +11,11 @@ spec:
       labels:
         app: {{ include "csi-gcs.fullname" . }}
     spec:
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        kubernetes.io/os: linux
-      priorityClassName: system-node-critical
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      priorityClassName: {{ include "csi-gcs.priorityClassName" . }}
       tolerations:
       - operator: "Exists"
       hostNetwork: true

--- a/deploy/helm/csi-gcs/templates/driver.yaml
+++ b/deploy/helm/csi-gcs/templates/driver.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: {{ .Values.driverName }}
+# https://kubernetes-csi.github.io/docs/csi-driver-object.html
+spec:
+  attachRequired: false
+  podInfoOnMount: true

--- a/deploy/helm/csi-gcs/templates/priorityclass.yaml
+++ b/deploy/helm/csi-gcs/templates/priorityclass.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.priorityClass.create }}
+apiVersion: scheduling.k8s.io/v1
+description: Priority class for the GCS driver
+kind: PriorityClass
+metadata:
+  name: {{ include "csi-gcs.priorityClassName" . }}
+preemptionPolicy: Never
+value: 1000000
+{{- end }}

--- a/deploy/helm/csi-gcs/templates/published-volumes-crd.yaml
+++ b/deploy/helm/csi-gcs/templates/published-volumes-crd.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: publishedvolumes.{{ .Values.driverName }}
+spec:
+  group: {{ .Values.driverName }}
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+  preserveUnknownFields: false
+  scope: Cluster
+  names:
+    plural: publishedvolumes
+    singular: publishedvolume
+    kind: PublishedVolume
+  validation:
+    openAPIV3Schema:
+      type: object
+      required:
+        - spec
+      properties:
+        spec:
+          type: object
+          required:
+            - node
+            - targetPath
+            - volumeHandle
+            - options
+            - pod
+          properties:
+            node:
+              type: string
+            targetPath:
+              type: string
+            volumeHandle:
+              type: string
+            options:
+              type: object
+              additionalProperties:
+                type: string
+            pod:
+              type: object
+              required:
+               - name
+               - namespace
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string

--- a/deploy/helm/csi-gcs/templates/rbac.yaml
+++ b/deploy/helm/csi-gcs/templates/rbac.yaml
@@ -1,0 +1,135 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "csi-gcs.serviceAccountName" . }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "csi-gcs.fullname" . }}-node
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["delete"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "update", "patch"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["volumeattachments"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["{{ .Values.driverName }}"]
+  resources: ["publishedvolumes"]
+  verbs: ["get", "list", "watch", "update", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "csi-gcs.fullname" . }}-node
+subjects:
+- kind: ServiceAccount
+  name: {{ include "csi-gcs.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "csi-gcs.fullname" . }}-node
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "csi-gcs.fullname" . }}-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "csi-gcs.fullname" . }}-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "csi-gcs.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "csi-gcs.fullname" . }}-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "csi-gcs.fullname" . }}-resizer
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "csi-gcs.fullname" . }}-resizer
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "csi-gcs.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "csi-gcs.fullname" . }}-resizer
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/csi-gcs/values.yaml
+++ b/deploy/helm/csi-gcs/values.yaml
@@ -6,6 +6,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+nodeSelector:
+  kubernetes.io/os: linux
+
 images:
   registrar:
     repository: gcr.io/gke-release/csi-node-driver-registrar #quay.io/k8scsi/csi-node-driver-registrar
@@ -21,6 +24,9 @@ images:
     tag: latest
   
 driverName: gcs.csi.ofek.dev
+priorityClass:
+  create: true
+  name: priorityclass-gcs
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/deploy/helm/csi-gcs/values.yaml
+++ b/deploy/helm/csi-gcs/values.yaml
@@ -1,0 +1,42 @@
+# Default values for csi-gcs.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+images:
+  registrar:
+    repository: gcr.io/gke-release/csi-node-driver-registrar #quay.io/k8scsi/csi-node-driver-registrar
+    tag: v1.2.0-gke.0
+  provisioner:
+    repository: gcr.io/gke-release/csi-provisioner #quay.io/k8scsi/csi-provisioner
+    tag: v1.6.0-gke.0
+  resizer:
+    repository: gcr.io/gke-release/csi-resizer #quay.io/k8scsi/csi-resizer
+    tag: v0.2.0-gke.0
+  driver:
+    repository: docker.io/ofekmeister/csi-gcs
+    tag: latest
+  
+driverName: gcs.csi.ofek.dev
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Having a helm chart makes it easier to add the driver as a dependency to other charts in a k8s deployment stack.

I can also help add testing, auto-packaging, and auto-version bumping as github actions if you wish, as we have for our charts.

Other than codifying the helm chart, one noticeable change is also the customizability of the priority class (and optional creation) as opposed to hardcoding `SystemCritical` so that the chart can be used in a user namespace. This is needed for our project where we isolate users by nodepool and namespace.

Many customizations can still be added but I only added the minimum that we needed to start.