### PR TITLE
fallback to key.json if key is not present

### DIFF
--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -95,13 +95,16 @@ func GetKey(secrets map[string]string, keyStoragePath string) (string, error) {
 
 	keyContents, keyNameExists := secrets["key"]
 	if !keyNameExists {
-		return "", status.Errorf(codes.Internal, "Secret '%s' is unavailable", "key")
+		keyContents, keyNameExists = secrets["key.json"]
+		if !keyNameExists {
+			return "", status.Errorf(codes.Internal, "Secret has no keys named '%s' or '%s'", "key", "key.json")
+		}
 	}
 
 	klog.V(5).Info("Saving key contents to a temporary location")
 	keyFile, err := CreateFile(keyStoragePath, keyContents)
 	if err != nil {
-		return "", status.Errorf(codes.Internal, "Unable to save secret 'key' to %s", keyStoragePath)
+		return "", status.Errorf(codes.Internal, "Unable to save secret 'key' / 'key.json' to %s", keyStoragePath)
 	}
 
 	return keyFile, nil

--- a/pkg/util/common_test.go
+++ b/pkg/util/common_test.go
@@ -1,10 +1,58 @@
 package util_test
 
 import (
-	// . "github.com/ofek/csi-gcs/pkg/util"
+	"io/ioutil"
+	"os"
+
+	. "github.com/ofek/csi-gcs/pkg/util"
 	. "github.com/onsi/ginkgo"
-	// . "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Common", func() {
+	Describe("GetKey", func() {
+		It("should error when neither 'key' nor 'key.json' are present", func() {
+			sec := map[string]string{}
+
+			_, err := GetKey(sec, "")
+			Expect(err).ShouldNot(Equal("Secret has no keys named 'key' or 'key.json'"))
+		})
+
+		It("should use 'key' first", func() {
+			sec := map[string]string{
+				"key":      "Content of key",
+				"key.json": "Content of key.json",
+			}
+
+			dir, err := ioutil.TempDir("", "test")
+			Expect(err).ShouldNot(HaveOccurred())
+			defer os.RemoveAll(dir)
+
+			s, err := GetKey(sec, dir)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(s).To(BeARegularFile())
+
+			f, err := os.Open(s)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ioutil.ReadAll(f)).To(BeEquivalentTo("Content of key"))
+		})
+
+		It("should fallback to 'key.json'", func() {
+			sec := map[string]string{
+				"key.json": "Content of key.json",
+			}
+
+			dir, err := ioutil.TempDir("", "test")
+			Expect(err).ShouldNot(HaveOccurred())
+			defer os.RemoveAll(dir)
+
+			s, err := GetKey(sec, dir)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(s).To(BeARegularFile())
+
+			f, err := os.Open(s)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(ioutil.ReadAll(f)).To(BeEquivalentTo("Content of key.json"))
+		})
+	})
 })


### PR DESCRIPTION
Background: When using [GCP config connector](https://cloud.google.com/config-connector/docs/overview), service account key secrets are created automatically with `key.json` as a key. This is not configurable.

Adding a fallback to csi-gcs seemed like the most straightforward solution.