### PR TITLE
Replace k8scsi quay.io docker images by registry.k8s.io/sig-storage (and upgrade csi-resizer docker image from 0.2.0 to 0.5.0)

### DIFF
--- a/deploy/base/daemonset.yaml
+++ b/deploy/base/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccount: csi-gcs
       containers:
       - name: csi-node-driver-registrar
-        image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v1.2.0
         imagePullPolicy: Always
         args:
         - "--v=5"
@@ -49,7 +49,7 @@ spec:
             cpu: 10m
             memory: 20Mi
       - name: csi-provisioner
-        image: quay.io/k8scsi/csi-provisioner:v1.6.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v1.6.0
         args:
           - "--csi-address=$(ADDRESS)"
           - "--extra-create-metadata"
@@ -65,7 +65,7 @@ spec:
           - name: socket-dir
             mountPath: /var/lib/csi/sockets/pluginproxy/
       - name: csi-resizer
-        image: quay.io/k8scsi/csi-resizer:v0.2.0
+        image: registry.k8s.io/sig-storage/csi-resizer:v0.5.0
         args:
           - "--v=5"
           - "--csi-address=$(ADDRESS)"

--- a/deploy/overlays/stable-gke/kustomization.yaml
+++ b/deploy/overlays/stable-gke/kustomization.yaml
@@ -11,4 +11,4 @@ images:
   newTag: v1.6.0-gke.0
 - name: registry.k8s.io/sig-storage/csi-resizer
   newName: gcr.io/gke-release/csi-resizer
-  newTag: v0.2.0-gke.0
+  newTag: v0.5.0-gke.0

--- a/deploy/overlays/stable-gke/kustomization.yaml
+++ b/deploy/overlays/stable-gke/kustomization.yaml
@@ -3,12 +3,12 @@ kind: Kustomization
 bases:
 - ../stable
 images:
-- name: quay.io/k8scsi/csi-node-driver-registrar
+- name: registry.k8s.io/sig-storage/csi-node-driver-registrar
   newName: gcr.io/gke-release/csi-node-driver-registrar
   newTag: v1.2.0-gke.0
-- name: quay.io/k8scsi/csi-provisioner
+- name: registry.k8s.io/sig-storage/csi-provisioner
   newName: gcr.io/gke-release/csi-provisioner
   newTag: v1.6.0-gke.0
-- name: quay.io/k8scsi/csi-resizer
+- name: registry.k8s.io/sig-storage/csi-resizer
   newName: gcr.io/gke-release/csi-resizer
   newTag: v0.2.0-gke.0


### PR DESCRIPTION
Following https://github.com/ofek/csi-gcs/issues/186, as main repo is no more working because images have been moved, i propose to update their paths.